### PR TITLE
Fix up format_data()

### DIFF
--- a/myretail_service/dev/helper.py
+++ b/myretail_service/dev/helper.py
@@ -1,3 +1,4 @@
+import ast
 import redis
 
 
@@ -16,7 +17,7 @@ class Helper(object):
         else:
             return False
 
-    def redis_read_pricing_info(self, id):
+    def redis_read_product_info(self, id):
         """
         :param id: id provided by GET response
 
@@ -64,9 +65,16 @@ class Helper(object):
 
        Format data that contains the pricing info from Redis and all other data from external API
        """
+
         formatted_search = {}
+        current_price_info = "Not defined in DB"
+        redis_result = self.redis_read_product_info(product_id)
+        if redis_result is not None:
+            # Pull current price info from redis_result if not None
+            redis_dict = ast.literal_eval(redis_result)
+            current_price_info = redis_dict['current_price']
         formatted_search['id'] = product_id
-        formatted_search['current_price'] = self.redis_read_pricing_info(product_id)
+        formatted_search['current_price'] = current_price_info
 
         # Since we already checked if data exists, we do not need to do another check here
         formatted_search['name'] = data['product']['item']['product_description']['title']

--- a/myretail_service/tests/unit_tests/test_main.py
+++ b/myretail_service/tests/unit_tests/test_main.py
@@ -60,7 +60,7 @@ class TestDataManagement(unittest.TestCase):
         }
 
     @mock.patch('myretail_service.dev.helper.Helper.product_exist')
-    @mock.patch('myretail_service.dev.helper.Helper.redis_read_pricing_info')
+    @mock.patch('myretail_service.dev.helper.Helper.redis_read_product_info')
     @mock.patch('myretail_service.dev.helper.Helper.format_data')
     def test_product_get(self, mock_format, mock_redis_read, mock_product_exist):
         # Test HTTP GET
@@ -82,7 +82,7 @@ class TestDataManagement(unittest.TestCase):
         self.assertNotEqual('Product not found.', response.data)
 
     @mock.patch('myretail_service.dev.helper.Helper.product_exist')
-    @mock.patch('myretail_service.dev.helper.Helper.redis_read_pricing_info')
+    @mock.patch('myretail_service.dev.helper.Helper.redis_read_product_info')
     @mock.patch('myretail_service.dev.helper.Helper.format_data')
     def test_product_else(self, mock_format, mock_redis_read, mock_product_exist):
         # Check that product returns general messsage if external api does not contain provided ID

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ envlist = py27,pep8
 passenv = *
 commands= py.test --cov myretail_service/dev --cov-report term-missing --cov-report xml --junitxml=junit-{envname}.xml {posargs}
 [testenv:pep8]
-commands =  flake8 my_retail --max-line-length=100
+commands =  flake8 myretail_service/ --max-line-length=100


### PR DESCRIPTION
There was an issue with format_data() where it was reading the whole
output of redis_read_product_info(). This fix adds logic to just add
the currency information from redis and to set a default string if no
data is read.

This change also updates the name of a function, adds unit tests to address
logic,and fixes an issue with pep8.